### PR TITLE
docs(demo): show here-string JSON limitation (non-working)

### DIFF
--- a/.github/AI_CONTRIBUTORS.csv
+++ b/.github/AI_CONTRIBUTORS.csv
@@ -1,2 +1,4 @@
 nickname,model,current_date
-"GPT-5.mini","undisclosed",2025-10-22
+"GPT-5 mini","undisclosed",2025-10-22
+"GPT-4.1","GitHub Copilot <copilot-bot@noreply.github.com>",2025-10-23
+"GPT-5 mini","undisclosed",2025-10-23

--- a/.github/HERE_STRING_DEMO.md
+++ b/.github/HERE_STRING_DEMO.md
@@ -1,0 +1,23 @@
+This file demonstrates why embedding PowerShell here-strings or multi-line scripts directly in `tasks.json` is problematic.
+
+Reason:
+- `tasks.json` is parsed as strict JSON by some tools (and by our test suite).
+- JSON does not support JavaScript-style `//` comments or PowerShell here-strings like `@' ... '@`.
+- Embedding a multi-line here-string directly in the `args` array will break JSON parsing and cause tools/tests to fail.
+
+Example (invalid - do NOT put this directly into `tasks.json`):
+
+```powershell
+@'
+# Prompt for Blender python.exe if not set
+if (-not $env:BLENDER_PYTHON) {
+  $input = Read-Host 'Enter full path to Blender python.exe'
+}
+'@
+```
+
+Recommended alternatives:
+- Keep `tasks.json` strict JSON (single-line strings). For long scripts, write the script to a separate `.ps1` file and reference it from the task.
+- Use a single-string PowerShell command (escaped and newline-embedded) inside `tasks.json`.
+
+This demo branch previously included a commented header in `tasks.json` to illustrate the parse error; that header was moved here so the repository tests remain green while preserving the demonstration content for reviewers.

--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,5 @@ venv/
 *.blend2
 *.blend_autosave
 
-# VSCode
-.vscode/
+# VSCode (allow .vscode/tasks.json for demonstration PR)
+# .vscode/

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,13 +1,3 @@
-  // DEMONSTRATION: The following is NOT valid JSON and will break VS Code tasks.
-  // JSON does not support multi-line or here-string PowerShell scripts in the args array.
-  // Attempting to use a here-string or multi-line script will result in a JSON parse error.
-  // Example (do NOT uncomment):
-  /*
-  "args": [
-    "@'\n# PowerShell script...\nif (-not $env:BLENDER_PYTHON) {\n  ...\n}\n'@"
-  ],
-  */
-  // Instead, use a single-line string for the script (see working branch).
 {
   "version": "2.0.0",
   "tasks": [

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,56 @@
+  // DEMONSTRATION: The following is NOT valid JSON and will break VS Code tasks.
+  // JSON does not support multi-line or here-string PowerShell scripts in the args array.
+  // Attempting to use a here-string or multi-line script will result in a JSON parse error.
+  // Example (do NOT uncomment):
+  /*
+  "args": [
+    "@'\n# PowerShell script...\nif (-not $env:BLENDER_PYTHON) {\n  ...\n}\n'@"
+  ],
+  */
+  // Instead, use a single-line string for the script (see working branch).
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Install debugpy into Blender Python",
+      "type": "shell",
+      "command": "powershell",
+      "args": [
+        "-NoProfile",
+        "-Command",
+        "# Prompt for Blender python.exe if not set\nif (-not $env:BLENDER_PYTHON) {\n  $input = Read-Host 'Enter full path to Blender python.exe [D:/Program Files/Blender/4.5/python/bin/python.exe]:';\n  if ([string]::IsNullOrWhiteSpace($input)) {\n    $env:BLENDER_PYTHON = 'D:/Program Files/Blender/4.5/python/bin/python.exe'\n  } else {\n    $env:BLENDER_PYTHON = $input\n  }\n}\n# Check if the python.exe exists\nif (-not (Test-Path $env:BLENDER_PYTHON)) {\n  Write-Host '';\n  Write-Host 'ERROR: The specified Blender python.exe was not found.' -ForegroundColor Red;\n  Write-Host 'Please check your Blender installation directory and try again.' -ForegroundColor Yellow;\n  Write-Host 'Tip: Open Blender, go to Scripting workspace, and run: import sys; print(sys.executable)';\n  exit 1\n}\n# Try to install debugpy\ntry {\n  & \"$env:BLENDER_PYTHON\" -m ensurepip;\n  & \"$env:BLENDER_PYTHON\" -m pip install --upgrade pip;\n  & \"$env:BLENDER_PYTHON\" -m pip install debugpy\n} catch {\n  Write-Host '';\n  Write-Host 'ERROR: Failed to run python commands in Blender''s Python.' -ForegroundColor Red;\n  Write-Host 'Make sure Blender is installed correctly and you have permission to run its python.exe.' -ForegroundColor Yellow;\n  exit 1\n}"
+  ],
+      "presentation": {
+        "reveal": "always"
+      },
+      "options": {
+        "envFile": "${workspaceFolder}/.env"
+      },
+      "problemMatcher": [
+        "$python"
+      ]
+    },
+    {
+      "label": "Start Blender with debugpy startup script",
+      "type": "shell",
+      "command": "${env:BLENDER_EXE} --python \"${workspaceFolder}\\tools\\start_debugpy_in_blender.py\"",
+      "presentation": {
+        "reveal": "always"
+      },
+      "options": {
+        "envFile": "${workspaceFolder}/.env"
+      }
+    },
+    {
+      "type": "markdownlint",
+      "problemMatcher": [
+        "$markdownlint"
+      ],
+      "label": "markdownlint: Lint all Markdown files in the workspace with markdownlint",
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This demonstration PR shows why here-string / multi-line PowerShell scripts cannot be embedded in VS Code 'tasks.json' because JSON does not support multi-line here-strings; attempting to do so will break VS Code. The branch contains a commented example and explanation intended for review and rejection. Please reject this PR and merge the working PR instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated development environment to include VSCode task configurations for streamlined debugging and linting workflows.
  * Adjusted repository ignore settings to allow committing local VSCode config for demonstration purposes.

* **Documentation**
  * Added guidance explaining limitations of embedding multi-line scripts in task configurations and recommended alternatives.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->