### PR TITLE
docs: add module-level docstrings

### DIFF
--- a/addons/lbff_all_in_one/__init__.py
+++ b/addons/lbff_all_in_one/__init__.py
@@ -1,4 +1,18 @@
 
+"""All-in-one addon loader for LBFF packages.
+
+This module provides a small loader that ensures a single LBFF main menu
+is available and then loads the individual LBFF addon modules listed in
+`ADDON_MODULES`. Addons should expose `register()` / `unregister()` and
+optionally a `classes` list; this loader will call `mod.register()` when
+present and print import/register errors to stderr.
+
+Design notes:
+- Keeps registration resilient: failures in one submodule don't stop
+    others from registering.
+- Maintains the LBFF menu ownership pattern used across the repository.
+"""
+
 bl_info = {
     "name": "LBFF All-in-One",
     "author": "You & Gemini",

--- a/addons/lbff_gaffer/__init__.py
+++ b/addons/lbff_gaffer/__init__.py
@@ -1,3 +1,11 @@
+"""Lighting tools addon (LBFF Gaffer).
+
+This addon provides small helpers to create standard lighting setups. The
+module follows the LBFF pattern for menus: it attempts to append its menu
+to the global `LBFF_MT_main_menu` and falls back to creating the main menu
+if it's not yet present (useful when the all-in-one loader isn't enabled).
+"""
+
 bl_info = {
     "name": "LBFF Gaffer",
     "author": "You & Gemini",

--- a/addons/lbff_minecraft_importer/__init__.py
+++ b/addons/lbff_minecraft_importer/__init__.py
@@ -1,4 +1,12 @@
 
+"""Minecraft importer addon wiring for LBFF.
+
+This module exposes the addon metadata and registers the importer operator
+and its submenu. It follows the LBFF pattern: try to append to the global
+`LBFF_MT_main_menu` if present, otherwise provide a small main menu so the
+sub-menu can be accessed.
+"""
+
 bl_info = {
     "name": "LBFF Minecraft Importer",
     "author": "You & Gemini",

--- a/addons/lbff_minecraft_importer/menus.py
+++ b/addons/lbff_minecraft_importer/menus.py
@@ -1,3 +1,8 @@
+"""Menus for the LBFF Minecraft importer addon.
+
+Provides a small submenu that exposes the importer operator.
+"""
+
 import bpy
 from .operators import LBFF_OT_import_minecraft_texture
 

--- a/addons/lbff_minecraft_importer/operators.py
+++ b/addons/lbff_minecraft_importer/operators.py
@@ -1,8 +1,19 @@
+"""Operators used by the LBFF Minecraft importer.
+
+These operators are intentionally small in the template repository; they
+provide a clear spot where the actual importer logic should be implemented.
+"""
+
 import bpy
 
 
 class LBFF_OT_import_minecraft_texture(bpy.types.Operator):
-    """Imports a Minecraft texture and creates a material"""
+    """Import a single Minecraft texture and create a Blender material.
+
+    The operator currently implements a no-op placeholder. Implementations
+    should locate the texture file, create an image datablock and construct
+    a material using appropriate shader nodes.
+    """
     bl_idname = "lbff.import_minecraft_texture"
     bl_label = "Import Minecraft Texture"
 


### PR DESCRIPTION
Adds module-level docstrings for addon modules (module docstrings only, no functional changes). This improves documentation coverage and helps static analysis tools. Please check that only docstrings are present and CI passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Minecraft Importer menu to the interface with texture import operator integration.

* **Documentation**
  * Enhanced addon module documentation with comprehensive docstrings for better clarity on addon functionality and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->